### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm install npm run dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### http://thelittlewonder.github.io/gpacalculator/
 ![forthebadge](https://forthebadge.com/images/badges/60-percent-of-the-time-works-every-time.svg)
 
-
+[![Run on Repl.it](https://repl.it/badge/github/thelittlewonder/gpacalculator)](https://repl.it/github/thelittlewonder/gpacalculator)
 ### Running Locally
 
 ``` bash


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Elizabeth11/gpacalculator).